### PR TITLE
Properly display jumbotron image and Adobe badge

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,11 +44,9 @@ li a:hover {
 	<body>
 		<div id="intro" class="jumbotron">
 			<div class="container">
-				<div class="row">
 				<h1>Brandon Smith</h1>
 
 				<p>This is where text goes</p>
-			</div>
 		</div>
 	</div>
 

--- a/main.css
+++ b/main.css
@@ -4,6 +4,7 @@
   max-height: 700px;
   background-repeat: no-repeat;
   background-size: cover;
+  background-position: left;
 }
 
 #bio {
@@ -17,4 +18,8 @@
 
 #bio p {
 
+}
+
+#acabadge {
+  max-width: 250px;
 }


### PR DESCRIPTION
I set a maximum width for the Adobe badge and changed where the jumbotron image starts so you can always see it properly.
