### PR TITLE
Override navbar bottom margin

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <style>
   ul {
       list-style-type: none;
-      margin: 0;
+      margin-bottom: 0 !important;
       padding: 0;
       overflow: hidden;
       background-color: #333;


### PR DESCRIPTION
Used a `!important` to override the bottom margin on the navbar.
